### PR TITLE
allow construction of RedirectRaw struct

### DIFF
--- a/src/modifiers.rs
+++ b/src/modifiers.rs
@@ -187,7 +187,7 @@ impl Modifier<Response> for Redirect {
 }
 
 /// A modifier for creating redirect responses.
-pub struct RedirectRaw(String);
+pub struct RedirectRaw(pub String);
 
 impl Modifier<Response> for RedirectRaw {
     fn modify(self, res: &mut Response) {


### PR DESCRIPTION
RedirectRaw is needed for redirection to urls which don't have special schemes e.g. steam:// or oob:// etc.

It isn't possible to actually construct a RedirectRaw at the moment though since the field is private.
